### PR TITLE
chore: FORGE-603 Upgrade Review Workflow plugin to BrXM v17

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Review/Assignment Workflow
+## 3.0.0
+FORGE-603 - Upgrade to v17
 ## 2.0.0
 FORGE-538 - Upgrade to v16
 ## 1.2.1

--- a/README.md
+++ b/README.md
@@ -240,15 +240,19 @@ Document link: http://localhost:8080/site/preview/news/2016/12/the-medusa-news.h
 
 These modules are not supported by Bloomreach and can be used as inspiration or only for demo purposes.
 
-#### 7. Use FakeSmtp as SMTP server for emails
+#### 7. Use MailHog as SMTP server for emails
 
-* Download  FakeSMTP from: [https://github.com/Nilhcem/FakeSMTP](https://github.com/Nilhcem/FakeSMTP)
+* Install MailHog:
+  * macOS: `brew install mailhog`
+  * Docker: `docker run -p 1025:1025 -p 8025:8025 mailhog/mailhog`
 
 * Run it as:
 
 ```bash
-java -jar fakeSMTP-2.0.jar -s  -p 2525 -a 127.0.0.1
+mailhog
 ```
+
+* SMTP listens on `127.0.0.1:1025`, web UI at [http://localhost:8025](http://localhost:8025)
 * Email module in demo project is already configured to use the above information
 
 ## Use

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The assigned group's members are the only ones that can accept or reject the req
 | 12.x | 0.2.x   |
 | 14.x | 1.2.1   |
 | 16.x | 2.0.0   |
+| 17.x | 3.0.0   |
 
 See [CHANGES](CHANGES.md) for release notes.
 

--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-cms-dependencies</artifactId>
   <packaging>pom</packaging>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-cms</artifactId>
   <packaging>war</packaging>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-essentials</artifactId>
   <packaging>war</packaging>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>My Project</name>
   <description>My Project</description>
   <groupId>org.example</groupId>
   <artifactId>myproject</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!--
@@ -387,6 +387,11 @@
                   <dependency>
                     <groupId>org.bloomreach.forge.review-workflow</groupId>
                     <artifactId>review-workflow-shared</artifactId>
+                    <classpath>shared</classpath>
+                  </dependency>
+                  <dependency>
+                    <groupId>org.eclipse.angus</groupId>
+                    <artifactId>angus-mail</artifactId>
                     <classpath>shared</classpath>
                   </dependency>
                 </dependencies>

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-repository-data</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data For Application</name>

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-repository-data</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data</name>

--- a/demo/repository-data/site-development/pom.xml
+++ b/demo/repository-data/site-development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-repository-data</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data For Site Development</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-repository-data</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-repository-data</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <name>My Project Repository Data Web Files</name>

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-site</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-components</artifactId>
   <packaging>jar</packaging>

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-site</artifactId>
   <packaging>pom</packaging>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>myproject-site</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>myproject-webapp</artifactId>
   <packaging>war</packaging>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.example</groupId>
       <artifactId>myproject-components</artifactId>
-      <version>2.0.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7.hst.toolkit-resources.addon</groupId>

--- a/demo/workflow-notifications/email-addon/pom.xml
+++ b/demo/workflow-notifications/email-addon/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.example</groupId>
         <artifactId>myproject-workflow-notifications</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>myproject-workflow-notifications-email-addon</artifactId>
@@ -28,16 +28,12 @@
 
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-email</artifactId>
-            <version>${commons-email.version}</version>
+            <artifactId>commons-email2-jakarta</artifactId>
+            <version>2.0.0-M1</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>mail</artifactId>
-                    <groupId>javax.mail</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>activation</artifactId>
-                    <groupId>javax.activation</groupId>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>jakarta.mail</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -49,9 +45,8 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commons-lang.version}</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
     </dependencies>

--- a/demo/workflow-notifications/email-addon/src/main/java/demo/hippo/email/FreemarkerParser.java
+++ b/demo/workflow-notifications/email-addon/src/main/java/demo/hippo/email/FreemarkerParser.java
@@ -5,7 +5,7 @@ import freemarker.cache.StringTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/demo/workflow-notifications/email-addon/src/main/java/demo/hippo/email/MailService.java
+++ b/demo/workflow-notifications/email-addon/src/main/java/demo/hippo/email/MailService.java
@@ -1,6 +1,6 @@
 package demo.hippo.email;
 
-import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail2.core.EmailException;
 
 public interface MailService {
 

--- a/demo/workflow-notifications/email-addon/src/main/java/demo/hippo/email/MailServiceImpl.java
+++ b/demo/workflow-notifications/email-addon/src/main/java/demo/hippo/email/MailServiceImpl.java
@@ -1,12 +1,12 @@
 package demo.hippo.email;
 
-import org.apache.commons.mail.EmailException;
-import org.apache.commons.mail.HtmlEmail;
-
-import javax.mail.Session;
-import java.util.Properties;
+import org.apache.commons.mail2.core.EmailException;
+import org.apache.commons.mail2.jakarta.HtmlEmail;
 
 public class MailServiceImpl implements MailService {
+
+    private static final String SMTP_HOST = "127.0.0.1";
+    private static final int SMTP_PORT = 1025;
 
     private String cmsRoot;
 
@@ -18,27 +18,14 @@ public class MailServiceImpl implements MailService {
     @Override
     public void sendMail(final String[] to, final String from, final String subject, final String html, final String text) throws EmailException {
         final HtmlEmail email = new HtmlEmail();
-
-        final Session session = getSession();
-        if (session == null) {
-            throw new EmailException("Unable to send mail; no mail session available");
-        }
-
-        email.setMailSession(session);
+        email.setHostName(SMTP_HOST);
+        email.setSmtpPort(SMTP_PORT);
         email.addTo(to);
         email.setFrom(from);
         email.setSubject(subject);
         email.setHtmlMsg(html);
         email.setTextMsg(text);
         email.send();
-    }
-
-    protected Session getSession() {
-        Properties props = new Properties();
-        props.put("mail.smtp.auth", "false");
-        props.put("mail.smtp.host", "127.0.0.1");
-        props.put("mail.smtp.port", "2525");
-        return Session.getInstance(props);
     }
 
     public String getCmsRoot() {

--- a/demo/workflow-notifications/event-handler/pom.xml
+++ b/demo/workflow-notifications/event-handler/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.example</groupId>
         <artifactId>myproject-workflow-notifications</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>myproject-workflow-notifications-event-handler</artifactId>
@@ -30,9 +30,8 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commons-lang.version}</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <dependency>

--- a/demo/workflow-notifications/event-handler/src/main/java/demo/hippo/notifications/NotificationsEventsListener.java
+++ b/demo/workflow-notifications/event-handler/src/main/java/demo/hippo/notifications/NotificationsEventsListener.java
@@ -1,7 +1,7 @@
 package demo.hippo.notifications;
 
 import demo.hippo.notifications.util.HippoUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.onehippo.cms7.event.HippoEventConstants;
 import org.onehippo.cms7.services.HippoServiceRegistry;
 import org.onehippo.cms7.services.eventbus.HippoEventListenerRegistry;

--- a/demo/workflow-notifications/event-handler/src/main/java/demo/hippo/notifications/NotificationsHandler.java
+++ b/demo/workflow-notifications/event-handler/src/main/java/demo/hippo/notifications/NotificationsHandler.java
@@ -7,7 +7,7 @@ import demo.hippo.notifications.util.HippoUtils;
 import demo.hippo.notifications.util.HtmlDiffGenerator;
 import demo.hippo.notifications.util.PreviewClient;
 import demo.hippo.notifications.util.PreviewClientUtil;
-import org.apache.commons.mail.EmailException;
+import org.apache.commons.mail2.core.EmailException;
 import org.onehippo.cms7.services.HippoServiceRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/demo/workflow-notifications/event-handler/src/main/java/demo/hippo/notifications/util/HtmlDiffGenerator.java
+++ b/demo/workflow-notifications/event-handler/src/main/java/demo/hippo/notifications/util/HtmlDiffGenerator.java
@@ -1,7 +1,7 @@
 package demo.hippo.notifications.util;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.WordUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.WordUtils;
 import org.hippoecm.htmldiff.DiffHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/demo/workflow-notifications/pom.xml
+++ b/demo/workflow-notifications/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.example</groupId>
         <artifactId>myproject</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>myproject-workflow-notifications</artifactId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bloomreach.forge.review-workflow</groupId>
         <artifactId>review-workflow</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Review Workflow Frontend</name>

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/dashboard/todo/TodoPlugin.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/dashboard/todo/TodoPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/AbstractAssignDialog.html
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/AbstractAssignDialog.html
@@ -1,5 +1,5 @@
 <!--
-  * Copyright 2024 Bloomreach B.V. (https://www.bloomreach.com)
+  * Copyright 2026 Bloomreach B.V. (https://www.bloomreach.com)
   *
   * Licensed under the Apache License, Version 2.0 (the  "License");
   * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/AbstractAssignDialog.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/AbstractAssignDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/AssignableGroupsProvider.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/AssignableGroupsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/InternalAssignDialog.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/InternalAssignDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/OnlineRequestDialog.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/OnlineRequestDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/ReviewRequestsWorkflowPlugin.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/ReviewRequestsWorkflowPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/request/ReviewRequestView.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/request/ReviewRequestView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/request/ReviewRequestWorkflowPlugin.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/request/ReviewRequestWorkflowPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/request/model/ReviewRequestModel.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/request/model/ReviewRequestModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/request/model/ReviewRequestWrapper.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/request/model/ReviewRequestWrapper.java
@@ -30,9 +30,11 @@ public class ReviewRequestWrapper extends Request {
     public ReviewRequestWrapper(final Request request, final Node requestNode) throws RepositoryException {
         super(
                 request.getId(),
+                request.getCreated(),
+                request.getReason(),
                 request.getSchedule(),
                 "review-" + requestNode.getProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_STATE).getString(),
-                Collections.singletonMap("infoRequest", request.getInfo())
+                Collections.singletonMap(Request.INFO_REQUEST, request.getInfo())
         );
         this.requestNode = requestNode;
     }
@@ -49,8 +51,13 @@ public class ReviewRequestWrapper extends Request {
         return requestNode.getProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_REVIEWEDBY).getString();
     }
 
-    public String getReason() throws RepositoryException {
-        return requestNode.getProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_REASON).getString();
+    @Override
+    public String getReason() {
+        try {
+            return requestNode.getProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_REASON).getString();
+        } catch (RepositoryException e) {
+            return null;
+        }
     }
 
     @Override

--- a/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/request/model/ReviewRequestWrapper.java
+++ b/frontend/src/main/java/org/bloomreach/forge/reviewworkflow/cms/reviewedactions/request/model/ReviewRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,15 +49,6 @@ public class ReviewRequestWrapper extends Request {
 
     public String getReviewedBy() throws RepositoryException {
         return requestNode.getProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_REVIEWEDBY).getString();
-    }
-
-    @Override
-    public String getReason() {
-        try {
-            return requestNode.getProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_REASON).getString();
-        } catch (RepositoryException e) {
-            return null;
-        }
     }
 
     @Override

--- a/hst/pom.xml
+++ b/hst/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bloomreach.forge.review-workflow</groupId>
         <artifactId>review-workflow</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Review Workflow HST</name>
@@ -53,6 +53,11 @@
             <groupId>org.onehippo.cms7</groupId>
             <artifactId>hippo-repository-builtin</artifactId>
             <version>${hippo.repository.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/hst/src/main/java/org/bloomreach/forge/reviewworkflow/hst/ExampleDocumentPreviewUrlService.java
+++ b/hst/src/main/java/org/bloomreach/forge/reviewworkflow/hst/ExampleDocumentPreviewUrlService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hst/src/main/java/org/bloomreach/forge/reviewworkflow/hst/ExampleReviewWorkflowComponent.java
+++ b/hst/src/main/java/org/bloomreach/forge/reviewworkflow/hst/ExampleReviewWorkflowComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hst/src/main/java/org/bloomreach/forge/reviewworkflow/hst/ExampleReviewWorkflowComponent.java
+++ b/hst/src/main/java/org/bloomreach/forge/reviewworkflow/hst/ExampleReviewWorkflowComponent.java
@@ -17,7 +17,7 @@ package org.bloomreach.forge.reviewworkflow.hst;
 
 import javax.jcr.RepositoryException;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.hippoecm.hst.component.support.bean.BaseHstComponent;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.core.component.HstComponentException;
@@ -69,7 +69,7 @@ public class ExampleReviewWorkflowComponent extends BaseHstComponent {
         if (value == null || value.trim().isEmpty()) {
             return null;
         }
-        return StringEscapeUtils.escapeHtml(value);
+        return StringEscapeUtils.escapeHtml4(value);
     }
 
 }

--- a/hst/src/main/java/org/bloomreach/forge/reviewworkflow/hst/ReviewWorkflowActions.java
+++ b/hst/src/main/java/org/bloomreach/forge/reviewworkflow/hst/ReviewWorkflowActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hst/src/main/resources/META-INF/hst-assembly/addon/module.xml
+++ b/hst/src/main/resources/META-INF/hst-assembly/addon/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  * Copyright 2024 Bloomreach B.V. (https://www.bloomreach.com)
+  * Copyright 2026 Bloomreach B.V. (https://www.bloomreach.com)
   *
   * Licensed under the Apache License, Version 2.0 (the  "License");
   * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <groupId>org.onehippo.cms7</groupId>
         <artifactId>hippo-cms7-release</artifactId>
-        <version>16.0.0</version>
+        <version>17.0.0</version>
     </parent>
 
     <name>brXM Review Workflow Addon</name>
     <description>Review Workflow Addon</description>
     <groupId>org.bloomreach.forge.review-workflow</groupId>
     <artifactId>review-workflow</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <url>https://www.bloomreach.com/</url>
     <inceptionYear>2016</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-<!--        <hippo.repository.version>14.2.0</hippo.repository.version>-->
-<!--        <hippo.hst.version>14.2.0</hippo.hst.version>-->
-<!--        <hippo.cms.version>14.2.0</hippo.cms.version>-->
-<!--        <hippo.plugin.selections.version>14.2.0</hippo.plugin.selections.version>-->
     </properties>
 
     <licenses>
@@ -100,7 +96,7 @@
     </distributionManagement>
 
     <issueManagement>
-        <url>https://issues.onehippo.com/browse/FORGE</url>
+        <url>https://bloomreach.atlassian.net/browse/FORGE</url>
     </issueManagement>
 
     <organization>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bloomreach.forge.review-workflow</groupId>
         <artifactId>review-workflow</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Review Workflow Repository</name>
@@ -24,6 +24,11 @@
             <groupId>org.bloomreach.forge.review-workflow</groupId>
             <artifactId>review-workflow-shared</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/documentworkflow/DocumentReviewWorkflowImpl.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/documentworkflow/DocumentReviewWorkflowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/documentworkflow/ReviewRequest.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/documentworkflow/ReviewRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/documentworkflow/ReviewRequest.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/documentworkflow/ReviewRequest.java
@@ -54,7 +54,11 @@ public class ReviewRequest extends Request {
         setStringProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_UUID, UUID.randomUUID().toString());
         setBooleanProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_CHECKED, false);
         setStringProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_STATE, "request");
-        setDateProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_CREATIONDATE, Calendar.getInstance().getTime());
+        final Calendar creationDate = Calendar.getInstance();
+        setDateProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_CREATIONDATE, creationDate.getTime());
+        setDateProperty(HippoStdPubWfNodeType.HIPPOSTDPUBWF_CREATION_DATE, creationDate.getTime());
+        setStringProperty(HippoStdPubWfNodeType.HIPPOSTDPUBWF_TYPE, "requestReview");
+        setStringProperty(HippoStdPubWfNodeType.HIPPOSTDPUBWF_USERNAME, owner);
         if (document != null) {
             getCheckedOutNode().setProperty(ReviewWorkflowNodeType.REVIEWWORKFLOW_DOCUMENT, document.getNode());
         }

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/documentworkflow/ReviewWorkflowDocumentHandle.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/documentworkflow/ReviewWorkflowDocumentHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/documentworkflow/ReviewWorkflowDocumentHandleFactory.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/documentworkflow/ReviewWorkflowDocumentHandleFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/AcceptReviewAction.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/AcceptReviewAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/AcceptReviewTask.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/AcceptReviewTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/AcceptReviewTask.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/AcceptReviewTask.java
@@ -19,7 +19,7 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bloomreach.forge.reviewworkflow.ReviewWorkflowNodeType;
 import org.hippoecm.repository.util.JcrUtils;
 import org.onehippo.repository.documentworkflow.Request;

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/IsEeligibleForReviewTask.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/IsEeligibleForReviewTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/IsEeligibleForReviewTask.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/IsEeligibleForReviewTask.java
@@ -18,7 +18,7 @@ package org.bloomreach.forge.reviewworkflow.repository.scxml;
 import javax.jcr.Node;
 import javax.jcr.Session;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bloomreach.forge.reviewworkflow.ReviewWorkflowNodeType;
 import org.bloomreach.forge.reviewworkflow.cms.workflow.ReviewWorkflowUtils;
 import org.hippoecm.repository.util.JcrUtils;

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/IsEligibleForReviewAction.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/IsEligibleForReviewAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/ListGroupsAction.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/ListGroupsAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/ListGroupsTask.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/ListGroupsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/OnlineRequestReviewAction.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/OnlineRequestReviewAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/OnlineRequestReviewTask.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/OnlineRequestReviewTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/RejectReviewAction.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/RejectReviewAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/RejectReviewTask.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/RejectReviewTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/RequestReviewAction.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/RequestReviewAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/RequestReviewTask.java
+++ b/repository/src/main/java/org/bloomreach/forge/reviewworkflow/repository/scxml/RequestReviewTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/repository/src/main/resources/hcm-config/configuration/modules/scxml/reviewworkflow.yaml
+++ b/repository/src/main/resources/hcm-config/configuration/modules/scxml/reviewworkflow.yaml
@@ -57,6 +57,14 @@ definitions:
         jcr:primaryType: hipposcxml:action
         hipposcxml:classname: org.onehippo.repository.documentworkflow.action.SetHolderAction
         hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /setTransferable:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.SetTransferableAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /setRetainable:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.SetRetainableAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
       /deleteRequest:
         jcr:primaryType: hipposcxml:action
         hipposcxml:classname: org.onehippo.repository.documentworkflow.action.DeleteRequestAction
@@ -68,6 +76,34 @@ definitions:
       /version:
         jcr:primaryType: hipposcxml:action
         hipposcxml:classname: org.onehippo.repository.documentworkflow.action.VersionVariantAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /listBranches:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.ListBranchesAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /branch:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.BranchAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /getBranch:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.GetBranchAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /checkoutBranch:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.CheckoutBranchAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /removeBranch:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.RemoveBranchAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /setPreReintegrationLabels:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.SetPreReintegrationLabelsAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /label:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.LabelAction
         hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
       /listVersions:
         jcr:primaryType: hipposcxml:action
@@ -85,6 +121,10 @@ definitions:
         jcr:primaryType: hipposcxml:action
         hipposcxml:classname: org.onehippo.repository.documentworkflow.action.VersionRestoreToAction
         hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /restoreVersionByVersion:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.RestoreVersionByVersionAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
       /workflowException:
         jcr:primaryType: hipposcxml:action
         hipposcxml:classname: org.onehippo.repository.scxml.WorkflowExceptionAction
@@ -96,6 +136,10 @@ definitions:
       /rejectRequest:
         jcr:primaryType: hipposcxml:action
         hipposcxml:classname: org.onehippo.repository.documentworkflow.action.RejectRequestAction
+        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
+      /listGroups:
+        jcr:primaryType: hipposcxml:action
+        hipposcxml:classname: org.bloomreach.forge.reviewworkflow.repository.scxml.ListGroupsAction
         hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
       /requestReview:
         jcr:primaryType: hipposcxml:action
@@ -116,40 +160,4 @@ definitions:
       /isEligibleForReview:
         jcr:primaryType: hipposcxml:action
         hipposcxml:classname: org.bloomreach.forge.reviewworkflow.repository.scxml.IsEligibleForReviewAction
-        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
-      /checkoutBranch:
-        jcr:primaryType: hipposcxml:action
-        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.CheckoutBranchAction
-        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
-      /restoreVersionByVersion:
-        jcr:primaryType: hipposcxml:action
-        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.RestoreVersionByVersionAction
-        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
-      /listBranches:
-        jcr:primaryType: hipposcxml:action
-        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.ListBranchesAction
-        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
-      /branch:
-        jcr:primaryType: hipposcxml:action
-        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.BranchAction
-        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
-      /getBranch:
-        jcr:primaryType: hipposcxml:action
-        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.GetBranchAction
-        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
-      /removeBranch:
-        jcr:primaryType: hipposcxml:action
-        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.RemoveBranchAction
-        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
-      /setPreReintegrationLabels:
-        jcr:primaryType: hipposcxml:action
-        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.SetPreReintegrationLabelsAction
-        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
-      /label:
-        jcr:primaryType: hipposcxml:action
-        hipposcxml:classname: org.onehippo.repository.documentworkflow.action.LabelAction
-        hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml
-      /listGroups:
-        jcr:primaryType: hipposcxml:action
-        hipposcxml:classname: org.bloomreach.forge.reviewworkflow.repository.scxml.ListGroupsAction
         hipposcxml:namespace: http://www.onehippo.org/cms7/repository/scxml

--- a/repository/src/main/resources/hcm-config/configuration/modules/scxml/workflow.xml
+++ b/repository/src/main/resources/hcm-config/configuration/modules/scxml/workflow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  Copyright 2013-2020 Hippo B.V. (http://www.onehippo.com)
+  Copyright 2013-2026 Bloomreach
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@
 
         // returns the variant for copying and checking copy access privileges
         def getCopySource() {
-        published ?: unpublished ?: null
+            published ?: unpublished ?: draft
         }
 
         // returns the variant for deleting and checking delete privileges
@@ -94,9 +94,13 @@
         holder == user
         }
 
-        // true if draft exists and not currently editor or edited by current user
+        // true if
+        // draft does not exist OR
+        // draft exists and not currently edited (no holder) OR
+        // edited by current user OR
+        // transferable
         def boolean isEditable() {
-        !holder or editor
+          !holder or editor or transferable
         }
 
         // true if published version (can be frozen node) for branchId exists
@@ -120,8 +124,7 @@
         }
 
         // true if unpublished variant exists and no published variant exists or they have a different lastModified
-        // note this 'modified' is a different one than hippo:isModified since hippo:isModified compares whether the
-        // draft has changes
+        // note this 'modified' is a different one than hippo:isModified since hippo:isModified compares whether the draft has changes
         def boolean isModified() {
         workflowData.isModified()
         }
@@ -152,12 +155,18 @@
         def boolean isCurrentUnpublishedVersioned() {
         workflowData.isCurrentUnpublishedVersioned(unpublished)
         }
+
+        // true if the current draft below the handle has the transferable status. The transferable status indicates
+        // that other uses can become the holder of the draft.
+        def boolean isTransferable() {
+          draft?.transferable and not requestPending
+        }
+
         // true if the currently logged-in user is part of the assignedGroup group.It's used to check whether a review
         // request can be reviewed by the currently logged in user
         def boolean isUserPartOfAssignedGroup(String assignedGroup){
         workflowData.groups.contains(assignedGroup)
         }
-
     </script>
 
     <!-- the initial no-document state is used to prevent entering the handle state if there is no document -->
@@ -197,10 +206,10 @@
                     <hippo:action action="commitEditableInstance" enabledExpr="false"/>
                 </onentry>
                 <!-- event-less transition to state "editing" if there is no pending request and the draft variant is edited -->
-                <transition target="editing" cond="editing"/>
+                <transition target="editing"  cond="editing and !transferable"/>
                 <!-- (else) event-less transition to state "editable" if there is no pending request and the draft variant
                             doesn't exist yet or isn't edited -->
-                <transition target="editable" cond="!requestPending or notMaster"/>
+                <transition target="editable" cond="!requestPending or notMaster or transferable"/>
             </state>
 
             <!-- editing state becomes active when the draft variant is currently edited -->
@@ -212,6 +221,9 @@
                         <!-- if current user is holder, (s)he is allowed to obtain editable instance -->
                         <hippo:action action="obtainEditableInstance" enabledExpr="true"/>
                         <hippo:action action="commitEditableInstance" enabledExpr="true"/>
+                        <if cond="!!draft and !unpublished and !published">
+                          <hippo:action action="saveDraft" enabledExpr="true"/>
+                        </if>
                         <else/>
                         <!-- for a not-current editor the current editor (holder) is reported through the 'inUseBy' feedback -->
                         <hippo:feedback key="inUseBy" value="holder"/>
@@ -223,7 +235,8 @@
                 </onentry>
             </state>
 
-            <!-- editable state becomes active if editing is possible but there is no current editor -->
+            <!-- editable state becomes active if editing is possible but there is no current editor or if
+            the draft is transferable -->
             <state id="editable">
                 <onentry>
                     <if cond="workflowContext.isGranted(draft,'hippo:admin')">
@@ -231,7 +244,13 @@
                         <hippo:action action="unlock" enabledExpr="false"/>
                     </if>
                     <!-- enable the operation to start editing -->
-                    <hippo:action action="obtainEditableInstance" enabledExpr="branchExists"/>
+                    <if cond="transferable">
+                      <hippo:action action="editDraft" enabledExpr="true"/>
+                      <hippo:action action="obtainEditableInstance" enabledExpr="branchExists and (!!unpublished or !!published)"/>
+                    <else>
+                        <hippo:action action="obtainEditableInstance" enabledExpr="branchExists"/>
+                    </else>
+                    </if>
                 </onentry>
             </state>
 
@@ -240,6 +259,8 @@
             <transition event="disposeEditableInstance">
                 <!-- remove holder from the draft document -->
                 <hippo:setHolder holder="null"/>
+                <hippo:setTransferable transferable="false"/>
+                <hippo:setRetainable retainable="false"/>
                 <hippo:result value="preview ? unpublished : published"/>
             </transition>
 
@@ -248,7 +269,7 @@
             <transition event="obtainEditableInstance">
                 <!-- copy/update draft unless user already is holder (editing) -->
 
-                <if cond="!editor">
+                <if cond="!editor or transferable">
                     <if cond="!!unpublished">
                         <!-- unpublished document exists -->
                         <!-- make sure the unpublished is the right branch -->
@@ -283,10 +304,25 @@
                 <hippo:result value="draft"/>
             </transition>
 
+            <!-- target-less transition to 'save' the current edited draft variant by adding the transferable property -->
+            <transition event="saveDraft">
+              <hippo:setTransferable transferable="true"/>
+              <hippo:setRetainable retainable="true"/>
+              <hippo:result value="draft"/>
+            </transition>
+
+            <!-- target-less transition to 'edit' the current edited draft -->
+            <transition event="editDraft">
+              <hippo:setHolder holder="user"/>
+              <hippo:setTransferable transferable="false"/>
+              <hippo:result value="draft"/>
+            </transition>
+
             <!-- target-less transition to 'commit' an editable instance by removing the holder and, if new or modified,
                  copying its content to the unpublished variant -->
             <transition event="commitEditableInstance">
                 <hippo:setHolder holder="null"/>
+                <hippo:setRetainable retainable="false"/>
                 <if cond="!!unpublished">
                     <!-- if unpublished variant exist only 'commit' changes if there are any -->
                     <hippo:isModified/>
@@ -316,6 +352,7 @@
                  with that of the current invoking admin (granted hippo:admin) user. -->
             <transition event="unlock">
                 <hippo:setHolder holder="user"/>
+                <hippo:setTransferable transferable="false"/>
             </transition>
 
         </state>
@@ -448,6 +485,7 @@
                     <cs:var name="workflowType" expr="request.workflowType"/>
                     <!-- store the request targetDate as temporary variable -->
                     <cs:var name="targetDate" expr="request.scheduledDate"/>
+                    <cs:var name="reason" expr="request.reason"/>
 
                     <!-- First delete the request itself.
                          Note: After this, the request object no longer can be accessed!
@@ -456,15 +494,25 @@
 
                     <hippo:deleteRequest requestExpr="request"/>
 
-                    <if cond="!targetDate">
-                        <!-- the request didn't have a targetDate defined, simply trigger the "workflowType" value as event -->
+                    <if cond="!targetDate and !reason">
+                      <!-- Case 1: neither reason nor targetDate exist -->
+                      <!-- the request didn't have a targetDate nor a reason defined, simply trigger the "workflowType" value as event -->
 
                         <send event="workflowType"/>
                         <!-- log the workflowType after it has been processed -->
                         <send event="'logEvent.'+workflowType"/>
-                        <else/>
-                        <!-- the request did have a targetDate: trigger a 'scheduled' workflow action event -->
+                    <elseif cond="!targetDate and reason">
+                        <!-- Case 2: reason exists, targetDate does not -->
+                        <send event="workflowType" namelist="reason"/>
+                    </elseif>
+                    <elseif cond="targetDate and !reason">
+                        <!-- Case 3: targetDate exists, reason does not -->
                         <send event="workflowType" namelist="targetDate"/>
+                    </elseif>
+                    <else/>
+                        <!-- Case 4: both reason and targetDate exist -->
+                        <!-- the request did have a targetDate and reason: trigger a 'scheduled' workflow action event -->
+                        <send event="workflowType" namelist="targetDate reason"/>
                     </if>
 
                 </transition>
@@ -495,7 +543,7 @@
                 <onentry>
                     <!-- by default report the request publication operation as available but disabled -->
                     <hippo:action action="requestPublication" enabledExpr="false"/>
-                    <if cond="workflowContext.isGranted(unpublished ?: published ?: draft, 'hippo:editor')">
+                    <if cond="workflowContext.isGranted(unpublished ?: published ?: draft, 'hippo:editor') and not transferable">
                         <!-- if editor user (granted hippo:editor) by default report the publish operation as available but disabled -->
                         <hippo:action action="publish" enabledExpr="false"/>
                     </if>
@@ -533,26 +581,47 @@
                     <hippo:action action="onlineRequestReview" enabledExpr="false"/>
                 </transition>
 
-                <!-- target-less transition to create a publish request when no event payload parameter targetDate is provided -->
-                <transition event="requestPublication" cond="!_event.data?.targetDate">
-                    <hippo:workflowRequest type="publish" contextVariantExpr="unpublished"/>
+                <!-- target-less transition to create a publish request when no event payload parameter targetDate and reason are provided -->
+                <transition event="requestPublication" cond="!_event.data?.targetDate and !_event.data?.reason">
+                  <hippo:workflowRequest type="publish" contextVariantExpr="unpublished"/>
                 </transition>
 
-                <!-- target-less transition to create a scheduledpublish request at the required event payload parameter targetDate -->
-                <transition event="requestPublication" cond="!!_event.data?.targetDate">
-                    <hippo:workflowRequest type="scheduledpublish" contextVariantExpr="unpublished"
-                                           targetDateExpr="_event.data?.targetDate"/>
+                <!-- Case 2: reason exists, targetDate does not -->
+                <transition event="requestPublication" cond="!_event.data?.targetDate and !!_event.data?.reason">
+                  <hippo:workflowRequest type="publish" contextVariantExpr="unpublished" reasonExpr="_event.data?.reason"/>
                 </transition>
 
-                <!-- target-less transition to publish the document when no event payload parameter targetDate is provided -->
-                <transition event="publish" cond="!_event.data?.targetDate">
+                <!-- Case 3: targetDate exists, reason does not -->
+                <transition event="requestPublication" cond="!!_event.data?.targetDate and !_event.data?.reason">
+                  <hippo:workflowRequest type="scheduledpublish" contextVariantExpr="unpublished" targetDateExpr="_event.data?.targetDate"/>
+                </transition>
+
+                <!-- target-less transition to create a scheduledpublish request at the required event payload parameter targetDate and a reason -->
+                <transition event="requestPublication" cond="!!_event.data?.targetDate and !!_event.data?.reason">
+                  <hippo:workflowRequest type="scheduledpublish" contextVariantExpr="unpublished" targetDateExpr="_event.data?.targetDate" reasonExpr="_event.data?.reason"/>
+                </transition>
+
+                <!-- target-less transition to publish the document when no event payload parameter targetDate and reason are provided -->
+                <transition event="publish" cond="!_event.data?.targetDate and !_event.data?.reason">
                     <!-- this will publish 'master' because no 'branchId' provided -->
                     <send event="'publishBranch'"/>
                 </transition>
 
-                <!-- target-less transition to schedule the publication of the document at the required event payload parameter targetDate -->
-                <transition event="publish" cond="!!_event.data?.targetDate">
+                <!-- Case 2: reason exists, targetDate does not -->
+                <transition event="publish" cond="!_event.data?.targetDate and !!_event.data?.reason">
+                  <!-- this will publish 'master' because no 'branchId' provided -->
+                  <cs:var name="reason" expr="_event.data?.reason"/>
+                  <send event="'publishBranch'" namelist="reason"/>
+                </transition>
+
+                <!-- Case 3: targetDate exists, reason does not -->
+                <transition event="publish" cond="!!_event.data?.targetDate and !_event.data?.reason">
                     <hippo:scheduleWorkflow type="publish" targetDateExpr="_event.data?.targetDate"/>
+                </transition>
+
+                <!-- target-less transition to schedule the publication of the document at the required event payload parameter targetDate and a reason -->
+                <transition event="publish" cond="!!_event.data?.targetDate and !!_event.data?.reason">
+                  <hippo:scheduleWorkflow type="publish" targetDateExpr="_event.data?.targetDate" reasonExpr="_event.data?.reason"/>
                 </transition>
 
             </state>
@@ -574,16 +643,16 @@
                     </if>
                 </onentry>
                 <!-- event-less transition to depublishable state if not currently editing and the document is 'live' -->
-                <transition target="depublishable" cond="!editing and live and master"/>
+                <transition target="depublishable" cond="(!editing or (transferable and editor) ) and live and master"/>
             </state>
 
             <!-- state depublishable is active when the  document is live and not currently edited -->
             <state id="depublishable">
                 <onentry>
-                    <if cond="(!requestPending or user=='workflowuser') and master">
+                    <if cond="(!requestPending or transferable or user=='workflowuser') and master">
                         <!-- if no request pending OR invoked by the 'workflowuser' user (scheduled workflow jobs daemon):
                              enable request depublication operation -->
-                        <hippo:action action="requestDepublication" enabledExpr="true"/>
+                        <hippo:action action="requestDepublication" enabledExpr="!transferable"/>
                         <if cond="workflowContext.isGranted(published, 'hippo:editor')">
                             <!-- if (also) editor user (granted hippo:editor): enable publish operation -->
                             <hippo:action action="depublish" enabledExpr="true"/>
@@ -591,25 +660,45 @@
                     </if>
                 </onentry>
 
-                <!-- target-less transition to create a depublish request when no event payload parameter targetDate is provided -->
-                <transition event="requestDepublication" cond="!_event.data?.targetDate">
+                <!-- target-less transition to create a depublish request when no event payload parameter targetDate and reason are provided -->
+                <transition event="requestDepublication" cond="!_event.data?.targetDate and !_event.data?.reason">
                     <hippo:workflowRequest type="depublish" contextVariantExpr="published"/>
                 </transition>
 
-                <!-- target-less transition to create a scheduleddepublish request at the required event payload parameter targetDate -->
-                <transition event="requestDepublication" cond="!!_event.data?.targetDate">
-                    <hippo:workflowRequest type="scheduleddepublish" contextVariantExpr="published"
-                                           targetDateExpr="_event.data?.targetDate"/>
+                <!-- Case 2: reason exists, targetDate does not -->
+                <transition event="requestDepublication" cond="!_event.data?.targetDate and !!_event.data?.reason">
+                  <hippo:workflowRequest type="depublish" contextVariantExpr="published" reasonExpr="_event.data?.reason"/>
                 </transition>
 
-                <!-- target-less transition to depublish the document when no event payload parameter targetDate is provided -->
-                <transition event="depublish" cond="!_event.data?.targetDate">
+                <!-- Case 3: targetDate exists, reason does not -->
+                <transition event="requestDepublication" cond="!!_event.data?.targetDate and !_event.data?.reason">
+                  <hippo:workflowRequest type="scheduleddepublish" contextVariantExpr="published" targetDateExpr="_event.data?.targetDate"/>
+                </transition>
+
+                <!-- target-less transition to create a scheduleddepublish request at the required event payload parameter targetDate and a reason -->
+                <transition event="requestDepublication" cond="!!_event.data?.targetDate and !!_event.data?.reason">
+                  <hippo:workflowRequest type="scheduleddepublish" contextVariantExpr="published" targetDateExpr="_event.data?.targetDate" reasonExpr="_event.data?.reason"/>
+                </transition>
+
+                <!-- target-less transition to depublish the document when no event payload parameter targetDate and reason are provided -->
+                <transition event="depublish" cond="!_event.data?.targetDate and !_event.data?.reason">
                     <send event="'depublishBranch'"/>
                 </transition>
 
-                <!-- target-less transition to schedule the depublication of the document at the required event payload parameter targetDate -->
-                <transition event="depublish" cond="!!_event.data?.targetDate">
+                <!-- Case 2: reason exists, targetDate does not -->
+                <transition event="depublish" cond="!_event.data?.targetDate and !!_event.data?.reason">
+                  <cs:var name="reason" expr="_event.data?.reason"/>
+                  <send event="'depublishBranch'" namelist="reason"/>
+                </transition>
+
+                <!-- Case 3: targetDate exists, reason does not -->
+                <transition event="depublish" cond="!!_event.data?.targetDate and !_event.data?.reason">
                     <hippo:scheduleWorkflow type="depublish" targetDateExpr="_event.data?.targetDate"/>
+                </transition>
+
+                <!-- target-less transition to schedule the depublication of the document at the required event payload parameter targetDate and a reason -->
+                <transition event="depublish" cond="!!_event.data?.targetDate and !!_event.data?.reason">
+                  <hippo:scheduleWorkflow type="depublish" targetDateExpr="_event.data?.targetDate" reasonExpr="_event.data?.reason"/>
                 </transition>
 
             </state>
@@ -884,7 +973,7 @@
 
         <state id="publish-branch">
             <onentry>
-                <if cond="workflowContext.isGranted(unpublished ?: published ?: draft, 'hippo:editor')">
+                <if cond="workflowContext.isGranted(unpublished ?: published ?: draft, 'hippo:editor') and not transferable">
                     <hippo:action action="publishBranch" enabledExpr="false"/>
                 </if>
             </onentry>
@@ -892,7 +981,7 @@
              currently not allowed or possible -->
             <state id="no-publish-branch">
                 <!-- event-less transition to 'can-publish-branch' state -->
-                <transition target="can-publish-branch" cond="!!unpublished and branchExists and modified"/>
+                <transition target="can-publish-branch" cond="!!unpublished and branchExists and modified and not transferable"/>
             </state>
             <state id="can-publish-branch">
                 <onentry>
@@ -939,7 +1028,11 @@
                         <!-- copy the content of the unpublished variant to the published variant -->
                         <hippo:copyVariant sourceState="unpublished" targetState="published"/>
                         <!-- mark the published variant as published and set its availability to (only) 'live' -->
-                        <hippo:configVariant variant="published" applyPublished="true" availabilities="live"/>
+                        <if cond="!_event.data?.reason">
+                              <hippo:configVariant variant="published" applyPublished="true" availabilities="live"/>
+                        <else/>
+                            <hippo:configVariant variant="published" applyPublished="true" availabilities="live" reasonExpr="_event.data?.reason"/>
+                        </if>
                         <!-- create a JCR version of the published document via the unpublished variant -->
                         <hippo:version variant="unpublished" trigger="publication"/>
                     </if>
@@ -989,7 +1082,11 @@
                             </if>
 
                             <!-- take the live variant offline -->
-                            <hippo:configVariant variant="published" availabilities=""/>
+                            <if cond="!_event.data?.reason">
+                                <hippo:configVariant variant="published" availabilities=""/>
+                            <else/>
+                                <hippo:configVariant variant="published" availabilities="" reasonExpr="_event.data?.reason"/>
+                            </if>
 
                             <hippo:checkoutBranch variant="unpublished" branchId="'*'" stateLabel="'published'"/>
 
@@ -998,7 +1095,11 @@
                                 <!-- copy the content of the unpublished variant to the published variant -->
                                 <hippo:copyVariant sourceState="unpublished" targetState="published"/>
                                 <!-- mark the published variant as published and set its availability to (only) 'live' -->
-                                <hippo:configVariant variant="published" applyPublished="true" availabilities="live"/>
+                                <if cond="!_event.data?.reason">
+                                    <hippo:configVariant variant="published" applyPublished="true" availabilities="live"/>
+                                <else/>
+                                    <hippo:configVariant variant="published" applyPublished="true" availabilities="live" reasonExpr="_event.data?.reason"/>
+                                </if>
                                 <!-- we do not need an extra version! -->
 
                                 <!-- we need to restore the preview of before! -->
@@ -1016,7 +1117,11 @@
                             <!-- ensure the unpublished variant to be versionable set its availability to (only) 'preview' -->
                             <hippo:configVariant variant="unpublished" versionable="true" availabilities="preview"/>
                             <!-- remove all availabilities from the published variant -->
-                            <hippo:configVariant variant="published" availabilities=""/>
+                            <if cond="!_event.data?.reason">
+                                <hippo:configVariant variant="published" availabilities=""/>
+                            <else/>
+                              <hippo:configVariant variant="published" availabilities="" reasonExpr="_event.data?.reason"/>
+                            </if>
                             <!-- create a first version of the current unpublished variant to be able to restore to later -->
                             <hippo:version variant="unpublished"/>
                         </if>
@@ -1044,7 +1149,7 @@
                     </if>
                 </onentry>
                 <!-- event-less transition to terminatable state if the document is not live and not being edited -->
-                <transition target="terminateable" cond="!anyBranchLive and !editing"/>
+                <transition target="terminateable" cond="!anyBranchLive and (!editing or (!!draft and !published and !unpublished and transferable))"/>
             </state>
 
             <!-- the terminateable state becomes active when the document is not live and not being edited -->
@@ -1086,8 +1191,8 @@
             <!-- the initial no-copy state is used and active when the user is not an author (granted hippo:author) -->
             <state id="no-copy">
                 <!-- event-less transition to copyable state when the user is an author (granted hippo:author) -->
-                <transition target="copyable"
-                            cond="workflowContext.isGranted(copySource,'hippo:author') and branchExists"/>
+                <transition target="copyable" cond="workflowContext.isGranted(copySource,'hippo:author') and branchExists and
+                ((!!published or !!unpublished) or (!!draft and !published and !unpublished and transferable))"/>
             </state>
 
             <!-- the state copyable is active for users which are author (granted hippo:author) -->

--- a/repository/src/main/resources/hcm-config/namespaces/reviewworkflow.cnd
+++ b/repository/src/main/resources/hcm-config/namespaces/reviewworkflow.cnd
@@ -13,3 +13,6 @@
     - reviewworkflow:creationdate (date)
     - reviewworkflow:uuid (string)
     - reviewworkflow:checked (boolean)
+    - hippostdpubwf:creationDate (date)
+    - hippostdpubwf:type (string)
+    - hippostdpubwf:username (string)

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bloomreach.forge.review-workflow</groupId>
         <artifactId>review-workflow</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Review Workflow Shared</name>

--- a/shared/src/main/java/org/bloomreach/forge/reviewworkflow/ReviewWorkflowNodeType.java
+++ b/shared/src/main/java/org/bloomreach/forge/reviewworkflow/ReviewWorkflowNodeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/org/bloomreach/forge/reviewworkflow/cms/workflow/ReviewWorkflow.java
+++ b/shared/src/main/java/org/bloomreach/forge/reviewworkflow/cms/workflow/ReviewWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/org/bloomreach/forge/reviewworkflow/cms/workflow/ReviewWorkflowUtils.java
+++ b/shared/src/main/java/org/bloomreach/forge/reviewworkflow/cms/workflow/ReviewWorkflowUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach (https://www.bloomreach.com)
+ * Copyright 2026 Bloomreach (https://www.bloomreach.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Bumps parent BOM from hippo-cms7-release 16.0.0 to 17.0.0 and project version to 3.0.0-SNAPSHOT across all modules.

Migrates commons-lang 2.x to commons-lang3 and commons-email to commons-email2-jakarta (Jakarta EE 10 compatible), fixing classloader conflicts caused by the bundled com.sun.mail jar.

Updates Request constructor call in ReviewRequestWrapper to match the revised v17 signature (id, created, reason, schedule, state, info).

Replaces deprecated FakeSMTP with MailHog for local email testing.

(co-authored with Claude Code)